### PR TITLE
Hotfix for new rsyslog impstats format that includes origin= fields

### DIFF
--- a/rsyslog-statcollector.py
+++ b/rsyslog-statcollector.py
@@ -85,7 +85,7 @@ def gen_metrics(line):
 
   raw_list = line.split(': ')
   _stats_timestamp = raw_list[0]
-  _stats_server = socket.getfqdn().replace('.','_')
+  _stats_server = socket.getfqdn().split('.')[0] # use short hostname when reporting metrics
   stat_msg = [raw_list[1].strip().translate(string.maketrans('-(', '_.'), '*/-)').strip(), ' '.join(raw_list[2:]).translate(string.maketrans('-', '_'), '()*/.-').strip()]
   stat_msg[0] = stat_msg[0].translate(string.maketrans(' ', '_'), ':')
   stat_msg[1] = dict((k, v) for k, v in [x.split('=') for x in stat_msg[1].strip().split(' ')])

--- a/rsyslog-statcollector.py
+++ b/rsyslog-statcollector.py
@@ -88,10 +88,12 @@ def gen_metrics(line):
   _stats_server = socket.getfqdn().replace('.','_')
   stat_msg = [raw_list[1].strip().translate(string.maketrans('-(', '_.'), '*/-)').strip(), ' '.join(raw_list[2:]).translate(string.maketrans('-', '_'), '()*/.-').strip()]
   stat_msg[0] = stat_msg[0].translate(string.maketrans(' ', '_'), ':')
-  stat_msg[1] = dict((k, int(v)) for k, v in [x.split('=') for x in stat_msg[1].strip().split(' ')])
+  stat_msg[1] = dict((k, v) for k, v in [x.split('=') for x in stat_msg[1].strip().split(' ')])
   for k, v in stat_msg[1].iteritems():
+    if k == "origin":
+      continue
     metric_name = stat_msg[0] + '.' + k
-    _stats_dict[metric_name] = v
+    _stats_dict[metric_name] = int(v)
   return (_stats_timestamp, _stats_server, _stats_dict)
 
 def submit(metric_root, filename, metrics, server):


### PR DESCRIPTION
Feel free to provide better way of fixing this - the new origin field that is not convertible to int()

Example log line in rsyslog 8.x:

```
Thu Sep 22 14:20:47 2016: action 15: origin=core.action processed=0 failed=0 suspended=0 suspended.duration=0 resumed=0
Thu Sep 22 14:20:47 2016: imrelp[20514]: origin=imrelp submitted=0
Thu Sep 22 14:20:47 2016: resource-usage: origin=impstats utime=0 stime=36130 maxrss=2020 minflt=488 majflt=0 inblock=0 oublock=2368 nvcsw=474 nivcsw=4
```
